### PR TITLE
Bugfix/terraform vnet

### DIFF
--- a/src/cloudlabs/deployer/terraform/terraform.tf_template
+++ b/src/cloudlabs/deployer/terraform/terraform.tf_template
@@ -33,7 +33,6 @@ resource "azurerm_virtual_network" "vnet" {
     subnet {
         name = "tfsub"
         address_prefix = "10.0.2.0/24"
-
     }
 }
 

--- a/src/cloudlabs/deployer/terraform/terraform.tf_template
+++ b/src/cloudlabs/deployer/terraform/terraform.tf_template
@@ -30,6 +30,11 @@ resource "azurerm_virtual_network" "vnet" {
     address_space = ["10.0.0.0/16"]
     location = "ukwest"
     resource_group_name = "${azurerm_resource_group.rg.name}"
+    subnet {
+        name = "tfsub"
+        address_prefix = "10.0.2.0/24"
+
+    }
 }
 
 # create subnet

--- a/src/cloudlabs/deployer/terraform/terraform.tf_template
+++ b/src/cloudlabs/deployer/terraform/terraform.tf_template
@@ -15,7 +15,7 @@ provider "azurerm" {
   client_secret   = "${var.azure_client_secret}"
   tenant_id       = "${var.azure_tenant_id}"
   # Don't upgrade to newer versions automatically
-  version = "~> 0.3"
+  version = "~> 1.1"
 }
 
 # create a resource group if it doesn't exist


### PR DESCRIPTION
This is an urgent fix which is now required to be able to deploy VMs on Azure. 

Azure API has changed and now it is mandatory to create a subnet within the virtual network. See the full API about Azure's [VirtualNetworkPropertiesFormat](https://docs.microsoft.com/en-us/azure/templates/microsoft.network/virtualnetworks#VirtualNetworkPropertiesFormat).

I've also updated the terraform template to use the latest version of Azure's plugin.

