### PR TITLE
Remove duplicate subnet definition in TF template

### DIFF
--- a/src/cloudlabs/deployer/terraform/terraform.tf_template
+++ b/src/cloudlabs/deployer/terraform/terraform.tf_template
@@ -24,7 +24,7 @@ resource "azurerm_resource_group" "rg" {
     location = "ukwest"
 }
 
-# create virtual network
+# create virtual network and subnet
 resource "azurerm_virtual_network" "vnet" {
     name = "tfvnet"
     address_space = ["10.0.0.0/16"]
@@ -36,13 +36,11 @@ resource "azurerm_virtual_network" "vnet" {
     }
 }
 
-# create subnet
-resource "azurerm_subnet" "subnet" {
-    name = "tfsub"
-    resource_group_name = "${azurerm_resource_group.rg.name}"
-    virtual_network_name = "${azurerm_virtual_network.vnet.name}"
-    address_prefix = "10.0.2.0/24"
-    #network_security_group_id = "${azurerm_network_security_group.nsg.id}"
+# get reference to subnet for other resources to use
+data "azurerm_subnet" "subnet" {
+  name                 = "tfsub"
+  virtual_network_name = "${azurerm_virtual_network.vnet.name}"
+  resource_group_name  = "${azurerm_resource_group.rg.name}"
 }
 
 # create public IPs
@@ -66,7 +64,7 @@ resource "azurerm_network_interface" "ni" {
 
     ip_configuration {
         name = "ipconfiguration"
-        subnet_id = "${azurerm_subnet.subnet.id}"
+        subnet_id = "${data.azurerm_subnet.subnet.id}"
         private_ip_address_allocation = "static"
         private_ip_address = "10.0.2.5"
         public_ip_address_id = "${azurerm_public_ip.ip.id}"


### PR DESCRIPTION
Resolves #62, as discussed there.

Is it worth it to change the name of the subnet to a variable, rather than have it hardcoded in both the virtual net definition and the subnet data source?