### PR TITLE
URL mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,19 +32,19 @@ export APP_SETTINGS=cloudlabs.config.DevConfig
 
 It is recommended that you create your own SSH key pair for local testing. Please name the keys `id_rsa_azure`.
 
-Note that if you want to run the tests locally, you'll need to configure `PRIVATE_SSH_KEY_PATH` so it points to the location where the private key is. The corresponding public key should then be in `$PRIVATE_SSH_KEY_PATH.pub`.  
+Note that if you want to run the tests locally, you'll need to configure `PRIVATE_SSH_KEY_PATH` so it points to the location where the private key is. The corresponding public key should then be in `$PRIVATE_SSH_KEY_PATH.pub`.
 
 Alternatively, you can also use `LocalDevConfig` if your keys are named `id_rsa_azure` and stored in `~/.ssh` like so:
 
 ```
-export APP_SETTINGS=cloudlabs.config.LocalDevConfig 
+export APP_SETTINGS=cloudlabs.config.LocalDevConfig
 ```
 
 
 ### Configure secrets
 
 Copy the file `src/cloudlabs/secrets.example.py` as `src/cloudlabs/secrets.py` and fill in suitable values.
-Ask a team member for the Azure credentials.
+Ask a team member for the Azure credentials and DNS information.
 
 ### Install the background task queue
 
@@ -179,6 +179,14 @@ sudo a2enmod wsgi shib2 ssl rewrite headers
 sudo a2ensite default-ssl
 sudo service apache2 restart
 ```
+
+Set up secrets:
+Copy the file `src/cloudlabs/secrets.example.py` as `src/cloudlabs/secrets.py` and fill in suitable values.
+There is an sample filled-in file in the private CloudLabs repository. In particular,
+choose the appropriate DNS IP, key name and key according to whether you want to
+access the production or development server (note that access to the DNS servers
+is restricted to particular source IPs, so this will have to be arranged if you
+are setting up a completely new machine).
 
 Set up Shibboleth:
 (the instructions here are for the staging server; for production, replace

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -23,6 +23,7 @@ pyaml
 
 # Azure
 azure-mgmt-compute>=3.0.1
+azure-mgmt-network
 azure-mgmt-resource
 
 # Rendering config file templates

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -28,3 +28,6 @@ azure-mgmt-resource
 
 # Rendering config file templates
 jinja2
+
+# Make DNS updates
+dnspython

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,9 +8,10 @@ adal==0.4.7               # via msrestazure
 alembic==0.9.3            # via flask-migrate
 amqp==2.2.1               # via kombu
 asn1crypto==0.23.0        # via cryptography
-azure-common==1.1.8       # via azure-mgmt-compute, azure-mgmt-resource
+azure-common==1.1.8       # via azure-mgmt-compute, azure-mgmt-network, azure-mgmt-resource
 azure-mgmt-compute==3.0.1
-azure-mgmt-nspkg==2.0.0   # via azure-mgmt-compute, azure-mgmt-resource
+azure-mgmt-network==1.7.1
+azure-mgmt-nspkg==2.0.0   # via azure-mgmt-compute, azure-mgmt-network, azure-mgmt-resource
 azure-mgmt-resource==1.2.2
 azure-nspkg==2.0.0        # via azure-common, azure-mgmt-nspkg
 billiard==3.5.0.3         # via celery
@@ -36,7 +37,7 @@ kombu==4.1.0              # via celery
 mako==1.0.7               # via alembic
 markupsafe==1.0           # via jinja2, mako
 msrest==0.4.19            # via msrestazure
-msrestazure==0.4.18       # via azure-mgmt-compute, azure-mgmt-resource
+msrestazure==0.4.18       # via azure-mgmt-compute, azure-mgmt-network, azure-mgmt-resource
 oauthlib==2.0.6           # via requests-oauthlib
 pathlib==1.0.1
 psycopg2==2.7.1

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -21,6 +21,7 @@ certifi==2017.11.5        # via msrest
 cffi==1.11.2              # via cryptography
 click==6.7                # via flask
 cryptography==2.1.4       # via adal
+dnspython==1.15.0
 flask-migrate==2.0.4
 flask-script==2.0.5       # via flask-migrate
 flask-sqlalchemy==2.2

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -21,6 +21,7 @@ certifi==2017.11.5        # via msrest
 cffi==1.11.2              # via cryptography
 click==6.7                # via flask, pip-tools
 cryptography==2.1.4       # via adal
+dnspython==1.15.0
 first==2.0.1              # via pip-tools
 flask-migrate==2.0.4
 flask-script==2.0.5       # via flask-migrate

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -8,9 +8,10 @@ adal==0.4.7               # via msrestazure
 alembic==0.9.3            # via flask-migrate
 amqp==2.2.1               # via kombu
 asn1crypto==0.23.0        # via cryptography
-azure-common==1.1.8       # via azure-mgmt-compute, azure-mgmt-resource
+azure-common==1.1.8       # via azure-mgmt-compute, azure-mgmt-network, azure-mgmt-resource
 azure-mgmt-compute==3.0.1
-azure-mgmt-nspkg==2.0.0   # via azure-mgmt-compute, azure-mgmt-resource
+azure-mgmt-network==1.7.1
+azure-mgmt-nspkg==2.0.0   # via azure-mgmt-compute, azure-mgmt-network, azure-mgmt-resource
 azure-mgmt-resource==1.2.2
 azure-nspkg==2.0.0        # via azure-common, azure-mgmt-nspkg
 billiard==3.5.0.3         # via celery
@@ -31,13 +32,13 @@ haikunator==2.1.0
 idna==2.6                 # via cryptography
 isodate==0.6.0            # via msrest
 itsdangerous==0.24        # via flask
-jinja2==2.9.6             # via flask
+jinja2==2.9.6
 keyring==10.5.0           # via msrestazure
 kombu==4.1.0              # via celery
 mako==1.0.7               # via alembic
 markupsafe==1.0           # via jinja2, mako
 msrest==0.4.19            # via msrestazure
-msrestazure==0.4.18       # via azure-mgmt-compute, azure-mgmt-resource
+msrestazure==0.4.18       # via azure-mgmt-compute, azure-mgmt-network, azure-mgmt-resource
 oauthlib==2.0.6           # via requests-oauthlib
 pathlib==1.0.1
 pip-tools==1.9.0

--- a/src/cloudlabs/__init__.py
+++ b/src/cloudlabs/__init__.py
@@ -1,0 +1,2 @@
+class CloudLabsException(Exception):
+    pass

--- a/src/cloudlabs/azure_tools.py
+++ b/src/cloudlabs/azure_tools.py
@@ -5,6 +5,7 @@ import logging
 
 from azure.common.credentials import ServicePrincipalCredentials
 from azure.mgmt.compute import ComputeManagementClient
+from azure.mgmt.network import NetworkManagementClient
 from azure.mgmt.resource import ResourceManagementClient
 
 from .host_status import HostStatus
@@ -120,6 +121,18 @@ class AzureTools(object):
                     # "stopped" still incurs charging; "deallocated" means truly off
                     return HostStatus.stopping
             return HostStatus.error  # uknown status, return error
+
+    def get_ip(self, host):
+        """Get the IP address of a host deployed on Azure as a string.
+
+        Returns None if the IP cannot be retrieved."""
+        try:
+            nmc = NetworkManagementClient(self.credentials, self.subscription_id)
+            ip = list(nmc.public_ip_addresses.list(group_name(host)))[0]
+            return ip.ip_address
+        except Exception:
+            logger.error("Could not retrieve IP of host %s", host.id)
+            return None
 
     def _get_credentials(self):
         """Get the necessary credentials for creating the management clients."""

--- a/src/cloudlabs/deployer/deployer.py
+++ b/src/cloudlabs/deployer/deployer.py
@@ -175,7 +175,7 @@ class Deployer:
             except Exception as e:
                 raise CloudLabsException("The URL mapping failed.") from e
         else:
-            logger.error("Could not get IP for host %s", host.id)
+            raise CloudLabsException("Could not get IP for host {}".format(host.id))
 
     def destroy(self, host):
         """Remove the given CloudLabs host from the cloud.

--- a/src/cloudlabs/deployer/deployer.py
+++ b/src/cloudlabs/deployer/deployer.py
@@ -173,6 +173,7 @@ class Deployer:
                 # 86400 is the "time to live" (a day, in seconds). This was set
                 # in the sample update script we were given, so reusing it here.
                 update.add(host.base_name, 86400, 'A', ip)
+                dns.query.tcp(update, Secrets.DNS_IP, timeout=10)
                 return ip
             except Exception as e:
                 raise CloudLabsException(
@@ -233,6 +234,7 @@ class Deployer:
             update = Update('cloudlabs.rc.ucl.ac.uk', keyring=keyring,
                             keyalgorithm=HMAC_SHA256)
             update.delete(host.base_name)
+            dns.query.tcp(update, Secrets.DNS_IP, timeout=10)
         except Exception as e:
             raise CloudLabsException("Undoing the URL mapping failed.") from e
 

--- a/src/cloudlabs/deployer/deployer.py
+++ b/src/cloudlabs/deployer/deployer.py
@@ -95,8 +95,9 @@ class Deployer:
             self._record_result(host, HostStatus.running)
             logger.info("Host %s successfully deployed", host.id)
             try:
-                self._map_url(host)
-                logger.info("Host %s successfully had its URL mapped", host.id)
+                ip = self._map_url(host)
+                logger.info("Host %s (%s) successfully had its URL mapped to %s",
+                            host.id, host.base_name, ip)
             except CloudLabsException as e:
                 logger.error("Host %s could not have its URL mapped:", host.id,
                              exc_info=e)
@@ -172,8 +173,10 @@ class Deployer:
                 # 86400 is the "time to live" (a day, in seconds). This was set
                 # in the sample update script we were given, so reusing it here.
                 update.add(host.base_name, 86400, 'A', ip)
+                return ip
             except Exception as e:
-                raise CloudLabsException("The URL mapping failed.") from e
+                raise CloudLabsException(
+                    "The URL mapping for {} failed.".format(ip)) from e
         else:
             raise CloudLabsException("Could not get IP for host {}".format(host.id))
 

--- a/src/cloudlabs/deployer/deployer.py
+++ b/src/cloudlabs/deployer/deployer.py
@@ -98,8 +98,8 @@ class Deployer:
                 self._map_url(host)
                 logger.info("Host %s successfully had its URL mapped", host.id)
             except CloudLabsException as e:
-                logger.error("Host %s could not have its URL mapped\n:" + e,
-                             host.id)
+                logger.error("Host %s could not have its URL mapped:", host.id,
+                             exc_info=e)
         else:
             self._record_result(host, HostStatus.error, 'apply', process.returncode)
             logger.error("Deployment of host %s failed (Terraform return code %s)",
@@ -218,8 +218,8 @@ class Deployer:
             self._unmap_url(host)
             logger.info("Host %s successfully had its URL unmapped", host.id)
         except CloudLabsException as e:
-            logger.error("Host %s could not have its URL unmapped\n:" + e,
-                         host.id)
+            logger.error("Host %s could not have its URL unmapped:", host.id,
+                         exc_info=e)
 
     def _unmap_url(self, host):
         """Undo the mapping from a UCL URL to Azure for the given Host."""

--- a/src/cloudlabs/deployer/deployer.py
+++ b/src/cloudlabs/deployer/deployer.py
@@ -213,6 +213,25 @@ class Deployer:
             self._record_result(host, HostStatus.error, 'destroy', process.returncode)
             logger.info("Destruction of host %s failed (Terraform return code %s)",
                         host.id, process.returncode)
+        # Delete the URL mapping regardless of whether Terraform succeeded
+        try:
+            self._unmap_url(host)
+            logger.info("Host %s successfully had its URL unmapped", host.id)
+        except CloudLabsException as e:
+            logger.error("Host %s could not have its URL unmapped\n:" + e,
+                         host.id)
+
+    def _unmap_url(self, host):
+        """Undo the mapping from a UCL URL to Azure for the given Host."""
+        try:
+            keyring = dns.tsigkeyring.from_text({
+                Secrets["DNS_KEYNAME"]: Secrets["DNS_KEY"]
+            })
+            update = Update('cloudlabs.rc.ucl.ac.uk', keyring=keyring,
+                            keyalgorithm=HMAC_SHA256)
+            update.delete(host.base_name)
+        except Exception as e:
+            raise CloudLabsException("Undoing the URL mapping failed.") from e
 
     def stop(self, host):
         """Stop a host that is running, but do not remove it from the cloud.
@@ -247,6 +266,13 @@ class Deployer:
         :param host: a Host instance"""
         self.tools.delete_VM(host)
         self._record_result(host, HostStatus.defining)
-        # remove the deploying task's ID from the database
+        # Remove the deploying task's ID from the database
         host.update(task=None)
         logger.info("Host %s and all its resources deleted", host.id)
+        # Unmap the URL from the ucl.ac.uk domain
+        try:
+            self._unmap_url(host)
+            logger.info("Host %s successfully had its URL unmapped", host.id)
+        except CloudLabsException as e:
+            logger.error("Host %s could not have its URL unmapped\n:" + e,
+                         host.id)

--- a/src/cloudlabs/deployer/deployer.py
+++ b/src/cloudlabs/deployer/deployer.py
@@ -166,7 +166,7 @@ class Deployer:
             # domain) to that IP.
             try:
                 keyring = dns.tsigkeyring.from_text({
-                    Secrets["DNS_KEYNAME"]: Secrets["DNS_KEY"]
+                    Secrets.DNS_KEYNAME: Secrets.DNS_KEY
                 })
                 update = Update('cloudlabs.rc.ucl.ac.uk', keyring=keyring,
                                 keyalgorithm=HMAC_SHA256)
@@ -228,7 +228,7 @@ class Deployer:
         """Undo the mapping from a UCL URL to Azure for the given Host."""
         try:
             keyring = dns.tsigkeyring.from_text({
-                Secrets["DNS_KEYNAME"]: Secrets["DNS_KEY"]
+                Secrets.DNS_KEYNAME: Secrets.DNS_KEY
             })
             update = Update('cloudlabs.rc.ucl.ac.uk', keyring=keyring,
                             keyalgorithm=HMAC_SHA256)

--- a/src/cloudlabs/models.py
+++ b/src/cloudlabs/models.py
@@ -177,8 +177,7 @@ class Host(Model):
     @property
     def link(self):
         """The full URL to this host when deployed, for use in href attributes."""
-        # return 'http://' + self.basic_url
-        return 'http://{}:{}'.format(names.azure_url(self.dns_name), self.port)
+        return 'http://{}:{}'.format(self.basic_url, self.port)
 
     @property
     def basic_url(self):

--- a/src/cloudlabs/models.py
+++ b/src/cloudlabs/models.py
@@ -185,6 +185,14 @@ class Host(Model):
         return self.base_name + '.cloudlabs.rc.ucl.ac.uk'
 
     @property
+    def underlying_url(self):
+        """The URL of the host in the underlying cloud provider.
+
+        Should primarily be used for testing, not user display.
+        """
+        return 'http://{}:{}'.format(names.azure_url(self.dns_name), self.port)
+
+    @property
     def auth_type(self):
         """Whether public key or password auth is used for this host."""
         if self.admin_ssh_key:

--- a/src/cloudlabs/secrets.example.py
+++ b/src/cloudlabs/secrets.example.py
@@ -22,6 +22,10 @@ class Secrets:
     TF_VAR_azure_client_secret = ""
     TF_VAR_azure_subscription_id = ""
 
+    # Key information for DNS udpates
+    DNS_KEYNAME = ""
+    DNS_KEY = ""
+
 
 def apply_secrets():
     """Place all the secrets in environment variables."""

--- a/src/cloudlabs/secrets.example.py
+++ b/src/cloudlabs/secrets.example.py
@@ -23,8 +23,9 @@ class Secrets:
     TF_VAR_azure_subscription_id = ""
 
     # Key information for DNS udpates
-    DNS_KEYNAME = ""
-    DNS_KEY = ""
+    DNS_KEYNAME = ""  # name of the key to use
+    DNS_KEY = ""  # secret key with which to sign requests to the DNS server
+    DNS_IP = ""  # IP address of the DNS server to update
 
 
 def apply_secrets():

--- a/src/test/test_deployer.py
+++ b/src/test/test_deployer.py
@@ -141,7 +141,7 @@ class TestDeployer:
         # Wait for 10 secs so we make sure app has had the time to be deployed.
         sleep(10)
         # URL and port are available through the host's link property
-        url = host.link
+        url = host.underlying_url
         # Check website is live
         response = requests.get(url)
         assert 200 == response.status_code


### PR DESCRIPTION
This will need to be tested from the staging server, since access to the DNS server is restricted. Fixes #17.

- [x] Map the Azure URL to one under the UCL domain once the machine has been created successfully
- [x] Delete this mapping when the machine is destroyed
- [x] Change the dashboard (and the host info page, or anywhere else?) so that it links to the UCL URL
- [x] Add instructions for setting up the secrets for accessing the DNS server to the README (under the section for the servers)
- [x] Add the keys etc to the private repository

- [x] ~Think about whether we need to check for name clashes? If someone creates a VM, could it override the mapping for an existing one (owned by another user, perhaps)? If we have key constraints in the DB for `base_name`, that should not be a problem. Or we could make a check before we actually send the request to the DNS server.~ `base_name` is declared with `unique=True` in the ORM schema, and has an associated uniqueness constraint in the DB (through its index), so this is not an issue.